### PR TITLE
fix: Pin Supabase JS to explicit version 2.44.1

### DIFF
--- a/form.js
+++ b/form.js
@@ -1,5 +1,5 @@
 // Importar Supabase
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.44.1/dist/module/supabase.js';
 // Configuración de Supabase (manteniendo los valores originales)
 const SUPABASE_URL = 'https://wiyejeeiehwfkdcbpomp.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndpeWVqZWVpZWh3ZmtkY2Jwb21wIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE1NjQwOTYsImV4cCI6MjA2NzE0MDA5Nn0.yDq4eOHujKH2nmg-F-DVnqCHGwdfEmf4Z968KXl1SDc'; // Clave original

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // Importar Supabase
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.44.1/dist/module/supabase.js';
 
 // Configuración de Supabase
 const SUPABASE_URL = 'https://wiyejeeiehwfkdcbpomp.supabase.co';

--- a/referencia.js
+++ b/referencia.js
@@ -1,5 +1,5 @@
 // Importar Supabase
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.44.1/dist/module/supabase.js';
 
 // Configuración de Supabase (debe ser la misma que en tus otros archivos JS)
 const SUPABASE_URL = 'https://wiyejeeiehwfkdcbpomp.supabase.co';

--- a/respuestas.js
+++ b/respuestas.js
@@ -1,5 +1,5 @@
 // Importar Supabase
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.44.1/dist/module/supabase.js';
 
 // Configuración de Supabase (manteniendo los valores originales)
 const SUPABASE_URL = 'https://wiyejeeiehwfkdcbpomp.supabase.co';


### PR DESCRIPTION
This commit resolves a recurring `TypeError: Cannot read properties of null (reading 'AuthClient')` by pinning the Supabase JS import to a specific, stable version (`2.44.1`) and pointing directly to the ES module file on the CDN.

Previous attempts to use more generic version specifiers (`@2` and `@2/+esm`) proved unreliable, as the CDN's resolution logic still resulted in an incompatible library version being loaded. Using the explicit URL (`https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.44.1/dist/module/supabase.js`) removes all ambiguity and guarantees that the correct, compatible version of the library is fetched.

This definitive fix has been applied to all JavaScript files that import Supabase:
- index.js
- form.js
- referencia.js
- respuestas.js